### PR TITLE
fix(Dockerfile): acceleration no such key error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,18 @@ COPY . .
 RUN git clone --depth 1 --branch v0.11.0 https://github.com/ipfs/go-ipfs && \
     cd go-ipfs && \
     go get github.com/ipfs/go-ds-s3/plugin@1ad440b && \
+    cd $GOPATH/pkg/mod/github.com/ipfs/go-ds-s3@v0.8.0 && \
+    git apply /workspace/remove_path_style.diff && \
+    cd /workspace/go-ipfs && \
+    go install github.com/ipfs/go-ds-s3/plugin && \
     cp ../preload_list plugin/loader/preload_list && \
     make build && go mod tidy && make build
 
 RUN cp /workspace/go-ipfs/cmd/ipfs/ipfs /usr/local/bin/
 
-RUN go-ipfs/cmd/ipfs/ipfs init && \
-    python3 configure.py --base-dir=/workspace/.ipfs \
+# Skip ipfs init and use copied directory .ipfs
+# RUN  go-ipfs/cmd/ipfs/ipfs init && \
+RUN python3 configure.py --base-dir=/workspace/.ipfs \
         --bucket=$S3_BUCKET_NAME \
         --region=$S3_REGION \
         --region-endpoint=$S3_REGION_ENDPOINT && \

--- a/configure.py
+++ b/configure.py
@@ -13,7 +13,7 @@ def create_datastore_spec(bucket: str, region: str) -> Dict:
                 'bucket': bucket,
                 'mountpoint': '/blocks',
                 'region': region,
-                'rootDirectory': '/blocks',
+                'rootDirectory': f'/{bucket}/blocks',
             },
             {
                 'mountpoint': '/',
@@ -31,7 +31,7 @@ def update_config(config: Dict, bucket: str, region: str, region_endpoint: str):
             'type': 's3ds',
             'region': region,
             'bucket': bucket,
-            'rootDirectory': '/blocks',
+            'rootDirectory': f'/{bucket}/blocks',
             'regionEndpoint': region_endpoint,
             'accessKey': '',
             'secretKey': '',

--- a/remove_path_style.diff
+++ b/remove_path_style.diff
@@ -1,0 +1,13 @@
+diff --git a/s3.go b/s3.go
+index cf035c8..b803d16 100644
+--- a/s3.go
++++ b/s3.go
+@@ -85,7 +85,7 @@ func NewS3Datastore(conf Config) (*S3Bucket, error) {
+        })
+
+        if conf.RegionEndpoint != "" {
+-               awsConfig.WithS3ForcePathStyle(true)
++//             awsConfig.WithS3ForcePathStyle(true)
+                awsConfig.WithEndpoint(conf.RegionEndpoint)
+        }
+

--- a/remove_path_style.diff
+++ b/remove_path_style.diff
@@ -3,11 +3,11 @@ index cf035c8..b803d16 100644
 --- a/s3.go
 +++ b/s3.go
 @@ -85,7 +85,7 @@ func NewS3Datastore(conf Config) (*S3Bucket, error) {
-        })
-
-        if conf.RegionEndpoint != "" {
--               awsConfig.WithS3ForcePathStyle(true)
-+//             awsConfig.WithS3ForcePathStyle(true)
-                awsConfig.WithEndpoint(conf.RegionEndpoint)
-        }
-
+ 	})
+ 
+ 	if conf.RegionEndpoint != "" {
+-		awsConfig.WithS3ForcePathStyle(true)
++//		awsConfig.WithS3ForcePathStyle(true)
+ 		awsConfig.WithEndpoint(conf.RegionEndpoint)
+ 	}
+ 


### PR DESCRIPTION
Please **DONOT** merge this PR. It's for review.

There's an error,
"Error: NoSuchKey: The specified key does not exist.", when running
ipfs bitswap reprovide.

An ipfs uses acceleration endpoint. And transfer acceleration
is only supported on virtual-hosted style requests.
https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html
But go-ds-s3 forces path style if region endpoint is set.

Apply patch remove_path_style.diff to go-ds-s3 to fix wrong config
when endpoint is acceleration. And update existing ipfs config
instead of run ipfs init to create a new one. Besides, update the
root directory of datastore spec from "/blocks" to
"/{bucket}/blocks" to make it compatible with existed wrong pathes
caused by path style and acceleration.