### PR TITLE
fix(Dockerfile): not find multihash in the dht

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ COPY . .
 RUN git clone --depth 1 --branch v0.11.0 https://github.com/ipfs/go-ipfs && \
     cd go-ipfs && \
     go get github.com/ipfs/go-ds-s3/plugin@1ad440b && \
+    cd $GOPATH/pkg/mod/github.com/ipfs/go-ds-s3@v0.8.0 && \
+    git apply /workspace/remove_path_style.diff && \
+    cd /workspace/go-ipfs && \
+    go install github.com/ipfs/go-ds-s3/plugin && \
     cp ../preload_list plugin/loader/preload_list && \
     make build && go mod tidy && make build
 
@@ -25,6 +29,8 @@ RUN go-ipfs/cmd/ipfs/ipfs init && \
         --bucket=$S3_BUCKET_NAME \
         --region=$S3_REGION \
         --region-endpoint=$S3_REGION_ENDPOINT && \
+    ipfs config --bool Experimental.AcceleratedDHTClient true && \
+    ipfs config Reprovider.Strategy roots && \
     ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001 && \
     ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
 

--- a/remove_path_style.diff
+++ b/remove_path_style.diff
@@ -1,0 +1,13 @@
+diff --git a/s3.go b/s3.go
+index cf035c8..b803d16 100644
+--- a/s3.go
++++ b/s3.go
+@@ -85,7 +85,7 @@ func NewS3Datastore(conf Config) (*S3Bucket, error) {
+ 	})
+ 
+ 	if conf.RegionEndpoint != "" {
+-		awsConfig.WithS3ForcePathStyle(true)
++//		awsConfig.WithS3ForcePathStyle(true)
+ 		awsConfig.WithEndpoint(conf.RegionEndpoint)
+ 	}
+ 


### PR DESCRIPTION
There was an error, Could not find the multihash in the dht, in
https://check.ipfs.network/.

There was an error,
"Error: NoSuchKey: The specified key does not exist.", when running
ipfs bitswap reprovide.

An ipfs uses acceleration endpoint. And transfer acceleration
is only supported on virtual-hosted style requests.
https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html
But go-ds-s3 forces path style if region endpoint is set.

Apply patch remove_path_style.diff to go-ds-s3 to fix wrong config
when endpoint is acceleration. Now ipfs bitswap reprovide works.
And for IPFS which has lots of pinned files, enable accelerated DHT
client to efficiently put provider records into the network and set
reprovider strategy to roots to only advertise provider records for
explicitly pinned content.